### PR TITLE
fix: VaList type for ARM64 architecture on linux

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,9 +81,9 @@ pub unsafe fn get_frame_duration(frame: *mut AVFrame) -> i64 {
     compile_error!("no frame duration support");
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", all(target_os = "linux", target_arch = "aarch64")))]
 type VaList = ffmpeg_sys_the_third::va_list;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", not(target_arch = "aarch64")))]
 type VaList = *mut ffmpeg_sys_the_third::__va_list_tag;
 #[cfg(target_os = "android")]
 type VaList = [u64; 4];


### PR DESCRIPTION
The library wasn’t compiling in Docker on a Mac (running Linux with ARM64) because of a problem with resolving the `VaList` type. This fix tweaks the `cfg` conditions to better handle `aarch64` on Linux.

```
54.48 error[E0412]: cannot find type `__va_list_tag` in crate `ffmpeg_sys_the_third`
54.48   --> /usr/local/cargo/git/checkouts/ffmpeg-rs-raw-3497e5db531ea4dd/a63b88e/src/lib.rs:87:42
54.48    |
54.48 87 | type VaList = *mut ffmpeg_sys_the_third::__va_list_tag;
54.48    |                                          ^^^^^^^^^^^^^ not found in `ffmpeg_sys_the_third`
54.48
54.52    Compiling infer v0.16.0
```